### PR TITLE
Make dist instead of all

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build tailscalesd
-        run: make all
+        run: make dist
       - name: Release tailscalesd
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Run `make dist` instead of `make all` for release, as `make all` now only generates the build for local development.