### PR TITLE
Optionally expose IPv6 target addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ a union of targets from both APIs.**
 
 - `-address` / `ADDRESS` is the host:port on which to serve TailscaleSD.
   Defaults to `0.0.0.0:9242`.
+- `-ipv6` / `EXPOSE_IPV6` instructs TailscaleSD to include IPv6 addresses in the
+  target list. **Be careful with this, the colons in IPv6 addresses wreak havoc
+  with Prometheus configurations!**
 - `-localapi` / `TAILSCALE_USE_LOCAL_API` instructs TailscaleSD to use the
   `tailscaled`-exported local API for discovery.
 - `-localapi_socket` / `TAILSCALE_LOCAL_API_SOCKET` is the path to the Unix

--- a/cmd/tailscalesd/main.go
+++ b/cmd/tailscalesd/main.go
@@ -56,7 +56,7 @@ func durationEnvVarWithDefault(key string, def time.Duration) time.Duration {
 
 func defineFlags() {
 	flag.BoolVar(&printVer, "version", false, "Print the version and exit.")
-	flag.BoolVar(&includeIPv6, "ipv6", false, "Include IPv6 target addresses.")
+	flag.BoolVar(&includeIPv6, "ipv6", boolEnvVarWithDefault("EXPOSE_IPV6", false), "Include IPv6 target addresses.")
 	flag.BoolVar(&useLocalAPI, "localapi", boolEnvVarWithDefault("TAILSCALE_USE_LOCAL_API", false), "Use the Tailscale local API exported by the local node's tailscaled")
 	flag.DurationVar(&pollLimit, "poll", durationEnvVarWithDefault("TAILSCALE_API_POLL_LIMIT", pollLimit), "Max frequency with which to poll the Tailscale API. Cached results are served between intervals.")
 	flag.StringVar(&address, "address", envVarWithDefault("LISTEN", address), "Address on which to serve Tailscale SD")

--- a/tailscalesd_test.go
+++ b/tailscalesd_test.go
@@ -103,9 +103,9 @@ func TestFilterIPv6Addresses(t *testing.T) {
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
-			got := filterIPv6Addresses(tc.descriptor)
+			got := FilterIPv6Addresses(tc.descriptor)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("filterIPv6Addresses: mismatch (-got, +want):\n%v", diff)
+				t.Errorf("FilterIPv6Addresses: mismatch (-got, +want):\n%v", diff)
 			}
 		})
 	}
@@ -114,7 +114,7 @@ func TestFilterIPv6Addresses(t *testing.T) {
 func TestTranslate(t *testing.T) {
 	for tn, tc := range map[string]struct {
 		devices []Device
-		filters []filter
+		filters []TargetFilter
 		want    []TargetDescriptor
 	}{
 		"zero": {},
@@ -221,7 +221,7 @@ func TestTranslate(t *testing.T) {
 					},
 				},
 			},
-			filters: []filter{
+			filters: []TargetFilter{
 				func(in TargetDescriptor) TargetDescriptor {
 					in.Labels["test_label"] = "IT WORKED"
 					return in
@@ -333,7 +333,7 @@ func TestDiscoveryHandler(t *testing.T) {
 			want: httpWant{
 				code:        http.StatusOK,
 				contentType: "application/json; charset=utf-8",
-				body:        `[{"targets":["100.2.3.4"],"labels":{"__meta_tailscale_api":"foo.example.com","__meta_tailscale_device_authorized":"false","__meta_tailscale_device_client_version":"420.69","__meta_tailscale_device_hostname":"somethingclever","__meta_tailscale_device_id":"id","__meta_tailscale_device_name":"somethingclever","__meta_tailscale_device_os":"beos","__meta_tailscale_device_tag":"tag:foo","__meta_tailscale_tailnet":"example@gmail.com"}},{"targets":["100.2.3.4"],"labels":{"__meta_tailscale_api":"foo.example.com","__meta_tailscale_device_authorized":"false","__meta_tailscale_device_client_version":"420.69","__meta_tailscale_device_hostname":"somethingclever","__meta_tailscale_device_id":"id","__meta_tailscale_device_name":"somethingclever","__meta_tailscale_device_os":"beos","__meta_tailscale_device_tag":"tag:bar","__meta_tailscale_tailnet":"example@gmail.com"}}]` + "\n",
+				body:        `[{"targets":["100.2.3.4","fd7a::1234"],"labels":{"__meta_tailscale_api":"foo.example.com","__meta_tailscale_device_authorized":"false","__meta_tailscale_device_client_version":"420.69","__meta_tailscale_device_hostname":"somethingclever","__meta_tailscale_device_id":"id","__meta_tailscale_device_name":"somethingclever","__meta_tailscale_device_os":"beos","__meta_tailscale_device_tag":"tag:foo","__meta_tailscale_tailnet":"example@gmail.com"}},{"targets":["100.2.3.4","fd7a::1234"],"labels":{"__meta_tailscale_api":"foo.example.com","__meta_tailscale_device_authorized":"false","__meta_tailscale_device_client_version":"420.69","__meta_tailscale_device_hostname":"somethingclever","__meta_tailscale_device_id":"id","__meta_tailscale_device_name":"somethingclever","__meta_tailscale_device_os":"beos","__meta_tailscale_device_tag":"tag:bar","__meta_tailscale_tailnet":"example@gmail.com"}}]` + "\n",
 			},
 		},
 		"results with no errors are served": {
@@ -361,7 +361,7 @@ func TestDiscoveryHandler(t *testing.T) {
 			want: httpWant{
 				code:        http.StatusOK,
 				contentType: "application/json; charset=utf-8",
-				body:        `[{"targets":["100.2.3.4"],"labels":{"__meta_tailscale_api":"foo.example.com","__meta_tailscale_device_authorized":"false","__meta_tailscale_device_client_version":"420.69","__meta_tailscale_device_hostname":"somethingclever","__meta_tailscale_device_id":"id","__meta_tailscale_device_name":"somethingclever","__meta_tailscale_device_os":"beos","__meta_tailscale_device_tag":"tag:foo","__meta_tailscale_tailnet":"example@gmail.com"}},{"targets":["100.2.3.4"],"labels":{"__meta_tailscale_api":"foo.example.com","__meta_tailscale_device_authorized":"false","__meta_tailscale_device_client_version":"420.69","__meta_tailscale_device_hostname":"somethingclever","__meta_tailscale_device_id":"id","__meta_tailscale_device_name":"somethingclever","__meta_tailscale_device_os":"beos","__meta_tailscale_device_tag":"tag:bar","__meta_tailscale_tailnet":"example@gmail.com"}}]` + "\n",
+				body:        `[{"targets":["100.2.3.4","fd7a::1234"],"labels":{"__meta_tailscale_api":"foo.example.com","__meta_tailscale_device_authorized":"false","__meta_tailscale_device_client_version":"420.69","__meta_tailscale_device_hostname":"somethingclever","__meta_tailscale_device_id":"id","__meta_tailscale_device_name":"somethingclever","__meta_tailscale_device_os":"beos","__meta_tailscale_device_tag":"tag:foo","__meta_tailscale_tailnet":"example@gmail.com"}},{"targets":["100.2.3.4","fd7a::1234"],"labels":{"__meta_tailscale_api":"foo.example.com","__meta_tailscale_device_authorized":"false","__meta_tailscale_device_client_version":"420.69","__meta_tailscale_device_hostname":"somethingclever","__meta_tailscale_device_id":"id","__meta_tailscale_device_name":"somethingclever","__meta_tailscale_device_os":"beos","__meta_tailscale_device_tag":"tag:bar","__meta_tailscale_tailnet":"example@gmail.com"}}]` + "\n",
 			},
 		},
 	} {


### PR DESCRIPTION
Optionally expose IPv6 target addresses.

API is updated to export the `filter` type as `TargetFilter`, and `Export` now takes a list of them to apply. The IPv6 filter is removed from the default set.

The `tailscalesd` binary now respects `-ipv6` / `EXPOSE_IPV6` to enable this feature.