### PR TITLE
Add multi-arch Docker image build

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,0 +1,1 @@
+tailscalesd

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,41 @@
+name: Docker images
+
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/cfunkhouser/tailscalesd
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.test
 *.yaml
 *.yml
+tailscalesd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.13 AS builder
+LABEL maintainer="Simon Elsbrock <simon@iodev.org>"
+LABEL org.opencontainers.image.description="Prometheus Service Discovery for Tailscale"
+
+COPY . ./build/tailscalesd/
+RUN cd ./build/tailscalesd && make
+
+FROM golang:1.13
+COPY --from=builder /go/build/tailscalesd/tailscalesd /tailscalesd
+
+ENTRYPOINT ["/tailscalesd"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.13 AS builder
+FROM golang:1 AS builder
 LABEL maintainer="Simon Elsbrock <simon@iodev.org>"
 LABEL org.opencontainers.image.description="Prometheus Service Discovery for Tailscale"
 
 COPY . ./build/tailscalesd/
 RUN cd ./build/tailscalesd && make
 
-FROM golang:1.13
+FROM golang:1
 COPY --from=builder /go/build/tailscalesd/tailscalesd /tailscalesd
 
 ENTRYPOINT ["/tailscalesd"]


### PR DESCRIPTION
This PR adds a multi-arch Docker image build using GitHub Actions. It currently builds for `linux/amd64`, `linux/arm/v7` and `linux/arm64/v8` and publishes into ghcr.io (I'm not sure about the fate of Docker Hub). Ideally we can make the image public.

Is that something that we could get merged?