### PR TITLE
Use -localapi_socket arg for the local API socket path

### DIFF
--- a/cmd/tailscalesd/main.go
+++ b/cmd/tailscalesd/main.go
@@ -17,7 +17,7 @@ import (
 var (
 	address        string = "0.0.0.0:9242"
 	includeIPv6    bool
-	localAPISocket string        = tailscalesd.PublicAPIHost
+	localAPISocket string        = tailscalesd.LocalAPISocket
 	pollLimit      time.Duration = time.Minute * 5
 	printVer       bool
 	tailnet        string
@@ -108,7 +108,7 @@ func main() {
 	var ts tailscalesd.MultiDiscoverer
 	if useLocalAPI {
 		ts = append(ts, &tailscalesd.RateLimitedDiscoverer{
-			Wrap:      tailscalesd.LocalAPI(tailscalesd.LocalAPISocket),
+			Wrap:      tailscalesd.LocalAPI(localAPISocket),
 			Frequency: pollLimit,
 		})
 	}


### PR DESCRIPTION
There was some severely confusing thing going on with -localapi_socket before, where it would default to the public API hostname, but then if you passed a different socket pathname as a cmdline parameter, it wouldn't connect to that.

This change straightens out the strings (defaulting to the reasonable default path for the local API socket, passing a value to the UNIX domain socket dialer if passed).