### PR TITLE
Rework the release process to use goreleaser

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,44 +1,31 @@
 name: Docker images
 
+# This workflow is now handled by the Release workflow using GoReleaser.
+# Docker images are built as part of the release process when tags are pushed.
+# This workflow is kept only for building and testing Docker images on PRs.
+
 on:
-  push:
-    branches:
-      - "main"
-    tags:
-      - "v*"
   pull_request:
     branches:
       - "main"
 
 jobs:
-  docker:
+  docker-pr:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image (test only)
+        uses: goreleaser/goreleaser-action@v6
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/cfunkhouser/tailscalesd
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,47 @@
-name: Publish Binaries on Release
+name: Release
 
 on:
   push:
     tags:
-      - v*
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
-  release-tailscalesd:
-    name: Release tailscalesd
+  release:
+    name: Release with GoReleaser
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Build tailscalesd
-        run: make dist
-      - name: Release tailscalesd
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: |
-            tailscalesd-darwin-amd64
-            tailscalesd-linux-amd64
-            tailscalesd-linux-arm6
-            tailscalesd-linux-arm7
-            tailscalesd-linux-386
-            SHA1SUM.txt
-            SHA256SUM.txt

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 *.yaml
 *.yml
 tailscalesd
+
+# GoReleaser
+!.goreleaser.yml
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,186 @@
+# GoReleaser configuration for tailscalesd
+# Documentation: https://goreleaser.com
+
+version: 2
+
+before:
+  hooks:
+    # Ensure dependencies are up to date
+    - go mod tidy
+    # Run tests before building
+    - go test ./...
+
+builds:
+  - id: tailscalesd
+    main: ./cmd/tailscalesd
+    binary: tailscalesd
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - 386
+    goarm:
+      - "7"
+    ignore:
+      # Windows doesn't support ARM variants we're targeting
+      - goos: windows
+        goarch: arm
+      # macOS doesn't support 386 or ARM variants
+      - goos: darwin
+        goarch: 386
+      - goos: darwin
+        goarch: arm
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+    flags:
+      - -trimpath
+
+archives:
+  - id: tailscalesd
+    formats:
+      - tar.gz
+      - zip
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^ci:'
+      - '^chore:'
+      - Merge pull request
+      - Merge branch
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: 'Bug fixes'
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: 'Performance improvements'
+      regexp: '^.*?perf(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: Others
+      order: 999
+
+dockers:
+  # Build Docker images for multiple architectures
+  - id: tailscalesd-amd64
+    use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/cfunkhouser/tailscalesd:{{ .Version }}-amd64"
+      - "ghcr.io/cfunkhouser/tailscalesd:latest-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.description=Prometheus Service Discovery for Tailscale"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
+  - id: tailscalesd-arm64
+    use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/cfunkhouser/tailscalesd:{{ .Version }}-arm64v8"
+      - "ghcr.io/cfunkhouser/tailscalesd:latest-arm64v8"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.description=Prometheus Service Discovery for Tailscale"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
+  - id: tailscalesd-armv7
+    use: buildx
+    goos: linux
+    goarch: arm
+    goarm: "7"
+    image_templates:
+      - "ghcr.io/cfunkhouser/tailscalesd:{{ .Version }}-armv7"
+      - "ghcr.io/cfunkhouser/tailscalesd:latest-armv7"
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.description=Prometheus Service Discovery for Tailscale"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
+docker_manifests:
+  # Create multi-arch manifest for version tag
+  - name_template: "ghcr.io/cfunkhouser/tailscalesd:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/cfunkhouser/tailscalesd:{{ .Version }}-amd64"
+      - "ghcr.io/cfunkhouser/tailscalesd:{{ .Version }}-arm64v8"
+      - "ghcr.io/cfunkhouser/tailscalesd:{{ .Version }}-armv7"
+
+  # Create multi-arch manifest for latest tag
+  - name_template: "ghcr.io/cfunkhouser/tailscalesd:latest"
+    image_templates:
+      - "ghcr.io/cfunkhouser/tailscalesd:latest-amd64"
+      - "ghcr.io/cfunkhouser/tailscalesd:latest-arm64v8"
+      - "ghcr.io/cfunkhouser/tailscalesd:latest-armv7"
+
+release:
+  github:
+    owner: cfunkhouser
+    name: tailscalesd
+  draft: false
+  prerelease: auto
+  mode: replace
+  header: |
+    ## TailscaleSD {{ .Version }}
+
+    Prometheus Service Discovery for Tailscale
+
+    ### Installation
+
+    Download the appropriate binary for your platform below, or use the Docker image:
+
+    ```bash
+    docker pull ghcr.io/cfunkhouser/tailscalesd:{{ .Version }}
+    ```
+
+  footer: |
+    ---
+    
+    **Full Changelog**: https://github.com/cfunkhouser/tailscalesd/compare/{{ .PreviousTag }}...{{ .Tag }}
+
+# Announce is disabled by default
+announce:
+  skip: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM golang:1 AS builder
+# Dockerfile for goreleaser builds
+# This is a minimal runtime container that receives the pre-built binary from goreleaser
+FROM gcr.io/distroless/static-debian12:nonroot
 LABEL maintainer="Simon Elsbrock <simon@iodev.org>"
 LABEL org.opencontainers.image.description="Prometheus Service Discovery for Tailscale"
 
-COPY . ./build/tailscalesd/
-RUN cd ./build/tailscalesd && make
-
-FROM golang:1
-COPY --from=builder /go/build/tailscalesd/tailscalesd /tailscalesd
+COPY tailscalesd /tailscalesd
 
 ENTRYPOINT ["/tailscalesd"]
 CMD []


### PR DESCRIPTION
- introduce goreleaser as a build and release tool
- amend the docker build process to create distroless images
- amend the docker workflow to use goreleaser's docker images
- amend the release workflow to use goreleaser

Also, while this is merging, mind releasing v0.4.0 with the changes I pushed your way last year? :D 