### PR TITLE
chore: Tune golanci-lint and address findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,21 @@
 version: "2"
 linters:
+  enable:
+    - bodyclose
+    - err113
+    - gocritic
+    - gocyclo
+    - gosec
+    - misspell
+    - noctx
+    - nolintlint
+    - revive
+    - sloglint
   settings:
     staticcheck:
       checks:
         - all # Enables all Staticcheck checks by default
         - '-SA1019' # Disables the SA1019 check for deprecated APIs.
+formatters:
+  enable:
+    - gofmt

--- a/cmd/tailscalesd/main.go
+++ b/cmd/tailscalesd/main.go
@@ -1,3 +1,4 @@
+// tailscalesd is a Prometheus service discovery exporter for tailnets.
 package main
 
 import (
@@ -15,16 +16,17 @@ import (
 )
 
 var (
-	address        string = "0.0.0.0:9242"
-	includeIPv6    bool
-	localAPISocket string        = tailscalesd.LocalAPISocket
-	pollLimit      time.Duration = time.Minute * 5
-	printVer       bool
-	tailnet        string
-	token          string
-	clientID       string
-	clientSecret   string
-	useLocalAPI    bool
+	address        = "0.0.0.0:9242"
+	localAPISocket = tailscalesd.LocalAPISocket
+	pollLimit      = time.Minute * 5
+
+	includeIPv6  bool
+	printVer     bool
+	tailnet      string
+	token        string
+	clientID     string
+	clientSecret string
+	useLocalAPI  bool
 
 	// Version of tailscalesd. Set at build time to something meaningful.
 	Version = "development"
@@ -145,6 +147,12 @@ func main() {
 	http.Handle("/", tailscalesd.Export(ts, filters...))
 
 	log.Printf("Serving Tailscale service discovery on %q", address)
-	log.Print(http.ListenAndServe(address, nil))
+	server := &http.Server{
+		Addr:         address,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	log.Print(server.ListenAndServe())
 	log.Print("Done")
 }

--- a/localapi.go
+++ b/localapi.go
@@ -92,7 +92,7 @@ func translatePeerToDevice(p *interestingPeerStatusSubset, d *Device) {
 	d.Hostname = p.HostName
 	d.ID = p.ID
 	d.OS = p.OS
-	d.Tags = p.Tags[:]
+	d.Tags = p.Tags
 }
 
 // Devices reported by the Tailscale local API as peers of the local host.

--- a/publicapi.go
+++ b/publicapi.go
@@ -74,12 +74,16 @@ func (a *publicAPIDiscoverer) Devices(ctx context.Context) ([]Device, error) {
 	return d.Devices, nil
 }
 
+// OAuthPublicAPIDiscoverer is a Discoverer which uses OAuth2 client credentials
+// to authenticate against the Tailscale Public API.
 type OAuthPublicAPIDiscoverer struct {
 	apiBase      string
 	clientID     string
 	clientSecret string
 }
 
+// Devices reported by the Tailscale public API as belonging to the configured
+// tailnet.
 func (a *OAuthPublicAPIDiscoverer) Devices(ctx context.Context) ([]Device, error) {
 	tailscale.I_Acknowledge_This_API_Is_Unstable = true // needed in order to use API clients.
 
@@ -131,7 +135,10 @@ func (a *OAuthPublicAPIDiscoverer) Devices(ctx context.Context) ([]Device, error
 	return devices, nil
 }
 
+// PublicAPIOption is an option for configuring PublicAPI Discoverers.
 type PublicAPIOption func(*publicAPIDiscoverer)
+
+// OAuthAPIOption is an option for configuring OAuthAPI Discoverers.
 type OAuthAPIOption func(*OAuthPublicAPIDiscoverer)
 
 // WithAPIHost sets the API base against which the PublicAPI Discoverers will

--- a/ratelimited.go
+++ b/ratelimited.go
@@ -38,6 +38,8 @@ func (c *RateLimitedDiscoverer) refreshDevices(ctx context.Context) ([]Device, e
 	return devices, nil
 }
 
+// Devices reported by the Tailscale public API as belonging to the configured
+// tailnet.
 func (c *RateLimitedDiscoverer) Devices(ctx context.Context) ([]Device, error) {
 	rateLimitedRequests.Inc()
 

--- a/ratelimited_test.go
+++ b/ratelimited_test.go
@@ -92,7 +92,7 @@ func TestRateLimitedDiscoverer(t *testing.T) {
 				},
 			},
 			wrapped: &testDiscoverer{
-				err: errors.New("this is a test error"),
+				err: errors.New("this is a test error"), //nolint:err113
 			},
 			want: rateLimitedDiscovererTestWant{
 				devices: []Device{

--- a/tailscalesd.go
+++ b/tailscalesd.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -185,7 +186,7 @@ func (h *discoveryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	devices, err := h.d.Devices(r.Context())
 	if err != nil {
-		if err != errStaleResults {
+		if !errors.Is(err, errStaleResults) {
 			w.WriteHeader(http.StatusInternalServerError)
 			serveAndLog(w, fmt.Sprintf("Failed to discover Tailscale devices: %v", err))
 			return
@@ -220,6 +221,6 @@ var defaultFilters = []TargetFilter{filterEmptyLabels}
 func Export(d Discoverer, with ...TargetFilter) http.Handler {
 	return &discoveryHandler{
 		d:       d,
-		filters: append(defaultFilters[:], with...),
+		filters: append(defaultFilters, with...),
 	}
 }

--- a/tailscalesd_test.go
+++ b/tailscalesd_test.go
@@ -300,7 +300,7 @@ func TestDiscoveryHandler(t *testing.T) {
 		},
 		"unspecified API error": {
 			discoverer: &testDiscoverer{
-				err: errors.New("this is a test error"),
+				err: errors.New("this is a test error"), //nolint:err113
 			},
 			want: httpWant{
 				code: http.StatusInternalServerError,


### PR DESCRIPTION
Enable the following linters, and address all findings.

- bodyclose
- err113
- gocritic
- gocyclo
- gosec
- misspell
- noctx
- nolintlint
- revive
- sloglint