### PR TITLE
Clean up the code

### DIFF
--- a/cmd/tailscalesd/main.go
+++ b/cmd/tailscalesd/main.go
@@ -160,7 +160,7 @@ func main() {
 			},
 		}
 	case useToken:
-		slog.Info("Using Public API with toke authentication for discovery")
+		slog.Info("Using Public API with token authentication for discovery")
 		ts = &tailscalesd.TailscaleAPIDiscoverer{
 			Client: &tailscale.Client{
 				APIKey:  token,

--- a/localapi.go
+++ b/localapi.go
@@ -15,6 +15,7 @@ type LocalAPIDiscoverer struct {
 	Client local.Client
 }
 
+// peerToDevice converts a PeerStatus from the local API to the internal Device format.
 func peerToDevice(p *ipnstate.PeerStatus, d *Device) {
 	for i := range p.TailscaleIPs {
 		d.Addresses = append(d.Addresses, p.TailscaleIPs[i].String())

--- a/localapi.go
+++ b/localapi.go
@@ -59,7 +59,7 @@ func (d *LocalAPIDiscoverer) Devices(ctx context.Context) ([]Device, error) {
 	return ret, nil
 }
 
-// LocalAPI Discoverer interrogates the Tailscale localapi for peer devices.
+// LocalAPI returns a Discoverer that interrogates the Tailscale local API for peer devices.
 func LocalAPI(socket string) *LocalAPIDiscoverer {
 	var ret LocalAPIDiscoverer
 	ret.Client.Socket = socket

--- a/metrics.go
+++ b/metrics.go
@@ -36,7 +36,7 @@ var (
 			Help: "Counter of all requests to a rate limited discoverer.",
 		})
 
-	rateLimitedRequestRefreshses = promauto.NewCounter(
+	rateLimitedRequestRefreshes = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Name: "tailscalesd_tailscale_rate_limited_refreshes",
 			Help: "Counter of requests to a rate limited discoverer which result in a data refresh.",
@@ -45,7 +45,7 @@ var (
 	rateLimitedStaleResults = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Name: "tailscalesd_tailscale_rate_limited_stale",
-			Help: "Counter of requests to a rate limited discoverer which result a return of stale results.",
+			Help: "Counter of requests to a rate limited discoverer which result in a return of stale results.",
 		})
 
 	tailnetDevicesPerTailnetGauge = promauto.NewGaugeVec(

--- a/ratelimited.go
+++ b/ratelimited.go
@@ -23,7 +23,7 @@ type RateLimitedDiscoverer struct {
 }
 
 func (c *RateLimitedDiscoverer) refreshDevices(ctx context.Context) ([]Device, error) {
-	rateLimitedRequestRefreshses.Inc()
+	rateLimitedRequestRefreshes.Inc()
 
 	devices, err := c.Wrap.Devices(ctx)
 	if err != nil {

--- a/tailscalesd.go
+++ b/tailscalesd.go
@@ -139,6 +139,8 @@ func filterEmptyLabels(td TargetDescriptor) TargetDescriptor {
 	}
 }
 
+// tagReplaceRe matches characters in Tailscale tags that are invalid in
+// Prometheus label names (colons and hyphens), to be replaced with underscores.
 var tagReplaceRe = regexp.MustCompile(`[:-]`)
 
 // tagToLabelKey translates a Tailscale tag to a Prometheus target label key.
@@ -166,7 +168,7 @@ func translate(devices []Device, filters ...TargetFilter) []TargetDescriptor {
 	for i, d := range devices {
 		found[i] = TargetDescriptor{
 			Targets: d.Addresses,
-			// All labels added here, except for tags.
+			// Base device labels. Tags are added separately below.
 			Labels: map[string]string{
 				LabelMetaAPI:                 d.API,
 				LabelMetaDeviceAuthorized:    fmt.Sprint(d.Authorized),

--- a/tailscalesd.go
+++ b/tailscalesd.go
@@ -37,7 +37,6 @@ const (
 	// LabelMetaDeviceID is the target's unique ID within Tailscale, as reported
 	// by the API. The public API reports this as a large integer. The local API
 	// reports a base64 string.
-	// string.
 	LabelMetaDeviceID = "__meta_tailscale_device_id"
 
 	// LabelMetaDeviceName is the name of the device as reported by the API. Not


### PR DESCRIPTION
Make the code more readable by fixing typos, adding and correcting comments, and standardizing receiver names.